### PR TITLE
Update to v1.0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,53 @@ Infrastructure
 * Access to ELK server with the logstash of your job scheduler
 * Access to VSC Account page
 
+## Accounting Reports
+
+Reports of the accounting stats can be generated in 3 formats:
+* rendered as plots or charts: choose SVG, PNG, JPG image format (`-f`)
+* rendered as plots/charts and including the resulting data in a separate CSV file (`-t`)
+* in a HTML document containing the plot/chart and related data tables (`-f html`)
+
+### Available reports
+
+* Reports with global statistics:
+  * **compute-time**: used compute time per node group. Top value is maximum compute capacity of the period
+  * **compute-percent**: percentage of compute capacity used per node group
+  * **running-jobs**: number of running jobs per node group
+  * **unique-users**: number of unique users running jobs per node group
+* Batch of individual reports:
+  * **peruser-compute**: used compute time per node group by each active user
+  * **peruser-percent**: percentage of compute time used per node group by each active user
+  * **peruser-jobs**: number of running jobs per node group by each active user
+  * **perfield-compute**: used compute time per node group by each research field
+  * **perfield-percent**: percentage of compute time used per node group by each research field
+  * **perfield-jobs**: number of running jobs per node group by each research field
+  * **persite-compute**: used compute time per node group by each research site
+  * **persite-percent**: percentage of compute time used per node group by each research site
+  * **persite-jobs**: number of running jobs per node group by each research site
+* Top rankings (pie charts and activity over time):
+  * **top-users**: compute time used by the top percentiles of users across all selected node groups
+  * **top-users-percent**: distribution of used compute time among top percentiles of users across all selected node groups
+  * **top-fields**: compute time used by each research field across all selected node groups
+  * **top-fields-percent**: distribution of used compute time among top research fields across all selected node groups
+  * **top-sites**: compute time used by each research site across all selected node groups
+  * **top-sites-percent**: distribution of used compute time among research sites across all selected node groups.
+
+## Example
+
+The following example generates 4 accounting reports:
+* **compute-percent**: total use of compute time (in percentage)
+* **running-jobs**: total amount of running jobs
+* **top-users-percent**: ranking of users by percentage of compute time
+* **top-sites-percent**: ranking of research sites by percentage of compute time
+
+```bash
+$ accounting-report compute-percent running-jobs top-users-percent top-sites-percent
+  -s 2020-01-01 -e 2020-06-30 -f html -o general-nodes -n node-group1 node-group2 -t
+```
+
+Reports will cover the first six months of 2020 (`-s 2020-01-01 -e 2020-06-30`) of two specific groups of nodes in the cluster (`-n node-group1 node-group2`). They will be saved in the folder `general-nodes` in the current working directory (`-o`), in HTML format (`-f html`) and also saving all data tables as CSV files (`-t`).
+
 ## Data Sources
 
 ### ElasticSearch
@@ -121,47 +168,3 @@ Configuration files and data files can also be located in `/etc`. Any files defi
 4. Package resources
 
 Alternatively, the location of those files can be set to any arbitrary absolute path. In such a case, the files in those paths will be used from their current location.
-
-## Accounting Reports
-
-Reports of the accounting stats can be generated in 3 formats:
-* rendered as plots or charts: choose SVG, PNG, JPG image format (`-f`)
-* rendered as plots/charts and including the resulting data in a separate CSV file (`-t`)
-* in a HTML document containing the plot/chart and related data tables (`-f html`)
-
-The following reports are available:
-* **compute-time**: used compute time per node group. Top value is maximum compute capacity of the period
-* **compute-percent**: percentage of compute capacity used per node group
-* **running-jobs**: number of running jobs per node group
-* **unique-users**: number of unique users running jobs per node group
-* **peruser-compute**: used compute time per node group by each active user (separate plot per user)
-* **peruser-percent**: percentage of compute time used per node group by each active user (separate plot per user)
-* **peruser-jobs**: number of running jobs per node group by each active user (separate plot per user)
-* **perfield-compute**: used compute time per node group by each research field (separate plot per field)
-* **perfield-percent**: percentage of compute time used per node group by each research field (separate plot per field)
-* **perfield-jobs**: number of running jobs per node group by each research field (separate plot per field)
-* **persite-compute**: used compute time per node group by each research site (separate plot per site)
-* **persite-percent**: percentage of compute time used per node group by each research site (separate plot per site)
-* **persite-jobs**: number of running jobs per node group by each research site (separate plot per site)
-* **top-users**: total compute time used by the top percentiles of users across selected node groups
-* **top-users-percent**: percentage of total compute time used by the top percentiles of users across selected node groups
-* **top-fields**: compute time used by each research field across selected node groups (plot over time and pie chart)
-* **top-fields-percent**: percentage of compute time used by each research field across selected node groups (plot over time and pie chart)
-* **top-sites**: total compute time used by each research site across selected node groups
-* **top-sites-percent**: percentage of total compute time used by each research site across selected node groups.
-
-## Example
-
-The following example generates 4 accounting reports:
-* **compute-percent**: total use of compute time (in percentage)
-* **running-jobs**: total amount of running jobs
-* **top-users-percent**: ranking of users by percentage of compute time
-* **top-sites-percent**: ranking of research sites by percentage of compute time
-
-```bash
-$ accounting-report compute-percent running-jobs top-users-percent top-sites-percent
-  -s 2020-01-01 -e 2020-06-30 -f html -o general-nodes -n node-group1 node-group2 -t
-```
-
-Reports will cover the first six months of 2020 (`-s 2020-01-01 -e 2020-06-30`) of two specific groups of nodes in the cluster (`-n node-group1 node-group2`). They will be saved in the folder `general-nodes` in the current working directory (`-o`), in HTML format (`-f html`) and also saving all data tables as CSV files (`-t`).
-

--- a/bin/accounting-report.py
+++ b/bin/accounting-report.py
@@ -27,26 +27,28 @@
 """
 Generate accurate accounting reports about the computational resources used in an HPC cluster
 
-Available reports:
+Reports with global statistics:
  - compute-time: used compute time per node group. Top value is maximum compute capacity of the period
  - compute-percent: percentage of compute capacity used per node group
  - running-jobs: number of running jobs per node group
  - unique-users: number of unique users running jobs per node group
- - peruser-compute: used compute time per node group by each active user (separate plot per user)
- - peruser-percent: percentage of compute time used per node group by each active user (separate plot per user)
- - peruser-jobs: number of running jobs per node group by each active user (separate plot per user)
- - perfield-compute: used compute time per node group by each research field (separate plot per field)
- - perfield-percent: percentage of compute time used per node group by each research field (separate plot per field)
- - perfield-jobs: number of running jobs per node group by each research field (separate plot per field)
- - persite-compute: used compute time per node group by each research site (separate plot per site)
- - persite-percent: percentage of compute time used per node group by each research site (separate plot per site)
- - persite-jobs: number of running jobs per node group by each research site (separate plot per site)
- - top-users: total compute time used by the top percentiles of users across selected node groups
- - top-users-percent: percentage of total compute time used by the top percentiles of users across selected node groups
- - top-fields: compute time used by each research field across selected node groups (plot over time and pie chart)
- - top-fields-percent: percentage of compute time used by each research field across selected node groups (plot over time and pie chart)
- - top-sites: total compute time used by each research site across selected node groups
- - top-sites-percent: percentage of total compute time used by each research site across selected node groups.
+Batch of individual reports:
+ - peruser-compute: used compute time per node group by each active user
+ - peruser-percent: percentage of compute time used per node group by each active user
+ - peruser-jobs: number of running jobs per node group by each active user
+ - perfield-compute: used compute time per node group by each research field
+ - perfield-percent: percentage of compute time used per node group by each research field
+ - perfield-jobs: number of running jobs per node group by each research field
+ - persite-compute: used compute time per node group by each research site
+ - persite-percent: percentage of compute time used per node group by each research site
+ - persite-jobs: number of running jobs per node group by each research site
+Top rankings (pie charts and activity over time):
+ - top-users: compute time used by the top percentiles of users across all selected node groups
+ - top-users-percent: distribution of used compute time among top percentiles of users across all selected node groups
+ - top-fields: compute time used by each research field across all selected node groups
+ - top-fields-percent: distribution of used compute time among top research fields across all selected node groups
+ - top-sites: compute time used by each research site across all selected node groups
+ - top-sites-percent: distribution of used compute time among research sites across all selected node groups.
 
 @author: Alex Domingo (Vrije Universiteit Brussel)
 """

--- a/lib/vsc/accounting/counters.py
+++ b/lib/vsc/accounting/counters.py
@@ -651,7 +651,7 @@ def get_joblist_ES(query_id, period_start, nodegroup_spec, logger=None):
     ES.set_source(extra=['jobid', 'username', 'exec_host', 'total_execution_slots'])
     logger.debug("'%s' ES query [%s]: %s", nodegroup, query_id, ES.search.to_dict())
 
-    ES.hits = pd.DataFrame([hit.to_dict() for hit in ES.search.scan()])
+    ES.hits = pd.DataFrame([hit.to_dict() for hit in ES.scan_hits()])
     logger.debug("'%s' ES query [%s] retrieved %s hits", nodegroup, query_id, len(ES.hits))
 
     # Calculate compute time for each job on this time period

--- a/lib/vsc/accounting/counters.py
+++ b/lib/vsc/accounting/counters.py
@@ -482,11 +482,14 @@ class ComputeTimeCount:
         rankings.append(percentile_rank)
         self.log.debug("Distributed %s %ss in percentiles by compute time", len(percentile_rank), aggregate)
 
+        # Strip any index names
+        for r, rank in enumerate(rankings):
+            rankings[r].index.name = None
         # Combine all series in a single data frame
         rankings = pd.concat(rankings, axis=1, sort=False)
         rankings = rankings.sort_values(by=['compute_time'], ascending=False)
 
-        # Calculate average length of time periods (some frequencies imply periods of different length)
+        # Calculate average length of time periods (some frequencies have periods of slightly different length)
         period_span = compute_data.index.to_series().diff().mean().days
         # Convert daily compute time to absolute compute time in the time period
         rankings['compute_time'] = rankings.loc[:, 'compute_time'] * period_span

--- a/lib/vsc/accounting/counters.py
+++ b/lib/vsc/accounting/counters.py
@@ -674,7 +674,7 @@ def get_joblist_ES(query_id, period_start, nodegroup_spec, logger=None):
     ES.set_source(extra=['jobid', 'username', 'exec_host', 'total_execution_slots'])
     logger.debug("'%s' ES query [%s]: %s", nodegroup, query_id, ES.search.to_dict())
 
-    ES.hits = pd.DataFrame([hit.to_dict() for hit in ES.scan_hits()])
+    ES.hits = pd.DataFrame(ES.scan_hits())
     logger.debug("'%s' ES query [%s] retrieved %s hits", nodegroup, query_id, len(ES.hits))
 
     # Calculate compute time for each job on this time period

--- a/lib/vsc/accounting/counters.py
+++ b/lib/vsc/accounting/counters.py
@@ -63,8 +63,8 @@ class ComputeUnits:
         self.log = fancylogger.getLogger(name=self.__class__.__name__)
 
         self.known_units = {
-            'corehours': {'name': 'corehours/day', 'shortname': 'chd', 'absolute': 'corehours', 'factor': 3600},
-            'coredays': {'name': 'coredays/day', 'shortname': 'cdd', 'absolute': 'coredays', 'factor': 86400},
+            'corehours': {'name': 'corehours', 'shortname': 'chd', 'freq': 'day', 'factor': 3600},
+            'coredays': {'name': 'coredays', 'shortname': 'cdd', 'freq': 'day', 'factor': 86400},
         }
 
         self.set_units(units)
@@ -80,6 +80,11 @@ class ComputeUnits:
             error_exit(self.log, errmsg)
         else:
             self.log.debug("Compute units set to '%s'", self.active_units['name'])
+
+        # Generate normalized name of the units
+        self.active_units['normname'] = self.active_units['name']
+        if self.active_units['freq']:
+            self.active_units['normname'] = f"{self.active_units['normname']}/{self.active_units['freq']}"
 
     def job_seconds_to_compute(self, job_time, used_cores, period_span):
         """

--- a/lib/vsc/accounting/data/userdb.py
+++ b/lib/vsc/accounting/data/userdb.py
@@ -42,6 +42,8 @@ from vsc.accounting.parallel import parallel_exec
 from vsc.accounting.config.parser import MainConf, ConfigFile
 from vsc.accounting.data.parser import DataFile
 
+UNKNOWN_FIELD = 'Unknown'
+
 
 class UserDB:
     """
@@ -163,7 +165,7 @@ def user_basic_record(username, logger=None):
         logger = fancylogger.getLogger()
 
     # Research field is always unknown in these cases
-    user_record = {'field': 'Unknown'}
+    user_record = {'field': UNKNOWN_FIELD}
 
     # Determine site of account
     site = (None, BRUSSEL, ANTWERPEN, LEUVEN, GENT)
@@ -228,9 +230,14 @@ def get_vsc_record(username, vsc_token, logger=None):
     else:
         logger.debug(f"[{username}] user account record retrieved from VSC account '{vsc_login['username']}'")
 
+        # only use first entry of research field
+        user_field = vsc_account['research_field'][0]
+        # use custom label for 'unknown' fields
+        if user_field == 'unknown':
+            user_field = UNKNOWN_FIELD
+
         user_record = {
-            # only use first entry of research field
-            'field': vsc_account['research_field'][0],
+            'field': user_field,
             'site': INSTITUTE_LONGNAME[vsc_account['person']['institute']['name']],
             'updated': date.today().isoformat(),
         }

--- a/lib/vsc/accounting/elasticsearch.py
+++ b/lib/vsc/accounting/elasticsearch.py
@@ -32,7 +32,7 @@ Data retrieval from ElasticSearch for vsc.accounting
 import pandas as pd
 
 from elasticsearch import Elasticsearch
-from elasticsearch.exceptions import ConnectionError, ConnectionTimeout, TransportError
+from elasticsearch.exceptions import ConnectionError, ConnectionTimeout, NotFoundError, TransportError
 from elasticsearch_dsl import Search
 
 from vsc.utils import fancylogger
@@ -176,3 +176,14 @@ class ElasticTorque:
 
         self.search = self.search.source(self.fields)
         self.log.debug("ES query [%s] retrieving fields: %s", self.id, ','.join(self.fields))
+
+    def scan_hits(self):
+        """
+        Scan all hits in Search object and handle any errors
+        """
+        try:
+            hits = [hit for hit in self.search.scan()]
+        except NotFoundError as err:
+            error_exit(self.log, f"ES query [{self.id}] search result not found: {err}")
+        else:
+            return hits

--- a/lib/vsc/accounting/elasticsearch.py
+++ b/lib/vsc/accounting/elasticsearch.py
@@ -182,7 +182,7 @@ class ElasticTorque:
         Scan all hits in Search object and handle any errors
         """
         try:
-            hits = [hit for hit in self.search.scan()]
+            hits = [hit.to_dict() for hit in self.search.scan()]
         except NotFoundError as err:
             error_exit(self.log, f"ES query [{self.id}] search result not found: {err}")
         else:

--- a/lib/vsc/accounting/plotter.py
+++ b/lib/vsc/accounting/plotter.py
@@ -610,7 +610,7 @@ class Plotter:
         try:
             self.fig.savefig(self.output_path[imgfmt], format=imgfmt, bbox_inches='tight')
         except PermissionError:
-            error_exit(f"Permission denied to save plot render: {imgpath}")
+            error_exit(f"Permission denied to save plot render: {self.output_path[imgfmt]}")
         else:
             self.log.info(f"Report for '{self.title}' saved in {imgfmt.upper()} format to {self.output_path[imgfmt]}")
 

--- a/lib/vsc/accounting/plotter.py
+++ b/lib/vsc/accounting/plotter.py
@@ -324,30 +324,30 @@ class Plotter:
 
     def date_freq(self):
         """
-        Return the frequency of the 'date' index in the plot's table
-        It needs to be calculated because DatetimeIndexes loose the freq attribute in Multiindexes
+        Return a readable label for frequency of the 'date' index in the plot's table
         """
-        # Number of days between consecutive dates
-        day_span = 0
+        freq_label = None
+
+        # Human readable names of DateOffset aliases
+        offset_name = {
+            'D': 'daily',
+            'W-MON': 'weekly',
+            'MS': 'monthly',
+            'QS': 'quarterly',
+            'AS': 'yearly',
+        }
+
         if 'date' in self.table.index.names:
-            dateidx = self.table.index.get_level_values('date').unique()
-            day_span = (dateidx[1] - dateidx[0]).days
+            # Get the offset alias from the table index
+            if self.table.index.nlevels == 1:
+                freq_offset = self.table.index.freqstr
+            else:
+                freq_offset = self.table.index.levels[0].freqstr
+            # Convert to a frequency label
+            if freq_offset in offset_name:
+                freq_label = offset_name[freq_offset]
 
-        # Frequency label
-        if day_span == 1:
-            freq_label = 'daily'
-        elif day_span == 7:
-            freq_label = 'weekly'
-        elif day_span > 25 and day_span < 32:
-            freq_label = 'monthly'
-        elif day_span > 80 and day_span < 100:
-            freq_label = 'quarterly'
-        elif day_span > 360 and day_span < 370:
-            freq_label = 'yearly'
-        else:
-            freq_label = None
-
-        self.log.debug("Plot date resolution re-determined to be %s", freq_label)
+            self.log.debug("Plot date resolution re-determined to be %s", freq_label)
 
         return freq_label
 

--- a/lib/vsc/accounting/plotter.py
+++ b/lib/vsc/accounting/plotter.py
@@ -364,6 +364,8 @@ class Plotter:
         except AttributeError as err:
             errmsg = f"Path to plot render for HTML page not found. Method self.set_output_paths() not called yet."
             error_exit(self.log, errmsg)
+        else:
+            img_source_path = os.path.basename(img_source_path)
 
         # Main titles
         page_title = self.title

--- a/lib/vsc/accounting/reports.py
+++ b/lib/vsc/accounting/reports.py
@@ -582,17 +582,20 @@ def top_fields(ComputeTime, percent, savedir, plotformat, csv=False):
 
     plot['table'] = pd.DataFrame(plot_stacks)
 
-    # Calculate maximum compute time used in time interval
+    # Total compute per time period
     ComputeTime.aggregate_perdate('GlobalStats', 'compute_time')
-    plot_max = max(ComputeTime.GlobalStats.loc[:, 'total_compute_time'])
+    plot_totals = ComputeTime.GlobalStats.loc[:, 'total_compute_time']
+    # Pick first series of total compute, all columns have same data
+    plot_totals = plot_totals.unstack().iloc[:, 0]
 
     if percent:
         plot_units = '%'
-        plot['table'] /= plot_max
+        plot['table'] = plot['table'].rename(columns={'compute_time': 'use_of_compute_time'})
+        plot['table'] = plot['table'].divide(plot_totals, axis=0, level=0)
         plot['ymax'] = 1
     else:
         plot_units = ComputeTime.compute_units['normname']
-        plot['ymax'] = plot_max
+        plot['ymax'] = max(plot_totals)
 
     # Add units to main column and set index date frequency
     th = simple_names_units(plot['table'].columns, plot_units)

--- a/lib/vsc/accounting/reports.py
+++ b/lib/vsc/accounting/reports.py
@@ -475,7 +475,8 @@ def top_users(ComputeTime, percent, savedir, plotformat, csv=False):
     areaplot = PlotterArea(**plot)
 
     # Format ranking of top users
-    top_users = format_ranking_table(top_users, ComputeTime.compute_units['name'])
+    ranking_units = (ComputeTime.compute_units['name'], ComputeTime.compute_units['absolute'])
+    top_users = format_ranking_table(top_users, *ranking_units)
     top_users.index.name = 'User'
     logger.debug("Data in the ranking table: %s", ", ".join(top_users.columns))
 
@@ -597,7 +598,8 @@ def top_fields(ComputeTime, percent, savedir, plotformat, csv=False):
     stackplot = PlotterStack(**plot)
 
     # Format ranking of top fields
-    top_fields = format_ranking_table(top_fields, ComputeTime.compute_units['name'])
+    ranking_units = (ComputeTime.compute_units['name'], ComputeTime.compute_units['absolute'])
+    top_fields = format_ranking_table(top_fields, *ranking_units)
     top_fields.index.name = 'Field'
     logger.debug("Data in the ranking table: %s", ", ".join(top_fields.columns))
 
@@ -706,7 +708,8 @@ def top_sites(ComputeTime, percent, savedir, plotformat, csv=False):
     lineplot = PlotterLine(**plot)
 
     # Format ranking of top fields
-    top_sites = format_ranking_table(top_sites, ComputeTime.compute_units['name'])
+    ranking_units = (ComputeTime.compute_units['name'], ComputeTime.compute_units['absolute'])
+    top_sites = format_ranking_table(top_sites, *ranking_units)
     top_sites.index.name = 'Site'
     logger.debug("Data in the ranking table: %s", ", ".join(top_sites.columns))
 
@@ -859,15 +862,16 @@ def source_data(counter, aggregate, compute_units):
     return sources
 
 
-def format_ranking_table(ranking, compute_units):
+def format_ranking_table(ranking, average_units, compute_units):
     """
     Common formating of ranking data frame to be outputted as table (HTML or CSV)
     - table: (DataFrame) ranking table from ComputeTimeFrame.rank_aggregate()
-    - compute_units: (string) long name of compute units
+    - average_units: (string) long name of average compute units
+    - compute_units: (string) long name of total compute units
     """
     ranking = ranking.loc[:, ['compute_average', 'compute_time', 'compute_percent']]
     th = {
-        'compute_average': f"Average Compute Time ({compute_units})",
+        'compute_average': f"Average Compute Time ({average_units})",
         'compute_time': f"Compute Time ({compute_units})",
         'compute_percent': 'Total Compute Used (%)',
     }

--- a/lib/vsc/accounting/reports.py
+++ b/lib/vsc/accounting/reports.py
@@ -459,20 +459,24 @@ def top_users(ComputeTime, percent, savedir, plotformat, csv=False):
 
     plot['table'] = pd.DataFrame(plot_stacks)
 
-    # Calculate maximum compute time used in time interval
+    # Total compute per time period
     ComputeTime.aggregate_perdate('GlobalStats', 'compute_time')
-    plot_max = max(ComputeTime.GlobalStats.loc[:, 'total_compute_time'])
+    plot_totals = ComputeTime.GlobalStats.loc[:, 'total_compute_time']
+    # Pick first series of total compute, all columns have same data
+    plot_totals = plot_totals.unstack().iloc[:, 0]
 
     if percent:
+        plot_ylabel = "Use of Compute Time"
         plot_units = '%'
-        plot['table'] /= plot_max
+        plot['table'] = plot['table'].divide(plot_totals, axis=0)
         plot['ymax'] = 1
     else:
+        plot_ylabel = column_title[0]
         plot_units = ComputeTime.compute_units['normname']
-        plot['ymax'] = plot_max
+        plot['ymax'] = max(plot_totals)
 
     # Add units to main column and set index date frequency
-    main_column = "{} ({})".format(column_title[0], plot_units)
+    main_column = "{} ({})".format(plot_ylabel, plot_units)
     plot['table'].columns = plot['table'].columns.set_levels([main_column], level=0)
     plot['table'].index.freq = ComputeTime.dates.freq
 

--- a/lib/vsc/accounting/reports.py
+++ b/lib/vsc/accounting/reports.py
@@ -695,22 +695,24 @@ def top_sites(ComputeTime, percent, savedir, plotformat, csv=False):
     plot_num = len(plot_sites)
     plot['table'] = ComputeTime.SiteCompute.loc[:, plot_sites].groupby('date').sum()
 
-    # Calculate maximum compute time used in time interval
+    # Total compute per time period
     ComputeTime.aggregate_perdate('GlobalStats', 'compute_time')
-    plot_max = max(ComputeTime.GlobalStats.loc[:, 'total_compute_time'])
+    plot_totals = ComputeTime.GlobalStats.loc[:, 'total_compute_time']
+    # Pick first series of total compute, all columns have same data
+    plot_totals = plot_totals.unstack().iloc[:, 0]
 
     if percent:
-        plot_ylabel = "Used Capacity"
+        plot_ylabel = "Use of Compute Time"
         plot_units = '%'
-        plot['table'] /= plot_max
+        plot['table'] = plot['table'].divide(plot_totals, axis=0)
         plot['ymax'] = 1
     else:
         plot_ylabel = "Compute Time"
         plot_units = ComputeTime.compute_units['normname']
-        plot['ymax'] = plot_max
+        plot['ymax'] = max(plot_totals)
 
     # Format column headers and set index date frequency
-    column_lvl = (["f{plot_ylabel} (f{plot_units})"], plot['table'].columns.to_list())
+    column_lvl = ([f"{plot_ylabel} ({plot_units})"], plot['table'].columns.to_list())
     plot['table'].columns = pd.MultiIndex.from_product(column_lvl)
     plot['table'].index.freq = ComputeTime.dates.freq
 

--- a/lib/vsc/accounting/reports.py
+++ b/lib/vsc/accounting/reports.py
@@ -61,7 +61,7 @@ def compute_time(ComputeTime, colorlist, savedir, plotformat, csv=False):
     # Full data table for the plot
     table_columns = ['compute_time', 'capacity', 'total_capacity']
     table = ComputeTime.GlobalStats.loc[:, table_columns]
-    units = ComputeTime.compute_units['name']
+    units = ComputeTime.compute_units['normname']
 
     # Format columns in the table and set index date frequency
     table = table.rename(columns=simple_names_units(table_columns, units))
@@ -129,10 +129,10 @@ def compute_percent(ComputeTime, colorlist, savedir, plotformat, csv=False):
 
     # Format columns in the table and set index date frequency
     th = {
-        'compute_time': f"Compute Time ({ComputeTime.compute_units['name']})",
-        'capacity': f"Capacity ({ComputeTime.compute_units['name']})",
+        'compute_time': f"Compute Time ({ComputeTime.compute_units['normname']})",
+        'capacity': f"Capacity ({ComputeTime.compute_units['normname']})",
         'percent_capacity': "Capacity Used (%)",
-        'total_capacity': f"Total Capacity ({ComputeTime.compute_units['name']})",
+        'total_capacity': f"Total Capacity ({ComputeTime.compute_units['normname']})",
         'percent_total_capacity': "Total Capacity Used (%)",
         'global_percent_capacity': "Total Capacity Used Globally (%)",
     }
@@ -198,7 +198,7 @@ def global_measure(ComputeTime, selection, colorlist, savedir, plotformat, csv=F
     table = ComputeTime.GlobalStats.loc[:, table_columns]
 
     # Format columns in the table and set index date frequency
-    units = [ComputeTime.compute_units['name'], 'jobs/day', 'jobs/day', 'users/day', 'users/day']
+    units = [ComputeTime.compute_units['normname'], 'jobs/day', 'jobs/day', 'users/day', 'users/day']
     table = table.rename(columns=simple_names_units(table_columns, units))
     table.index.levels[0].freq = ComputeTime.dates.freq
     logger.debug("Data included in the report: %s", ", ".join(table.columns))
@@ -257,7 +257,7 @@ def aggregates(ComputeTime, aggregate, selection, percent, colorlist, savedir, p
 
     # Source data for selected accounting and aggregate
     try:
-        sources = source_data(selection, aggregate, ComputeTime.compute_units['name'])
+        sources = source_data(selection, aggregate, ComputeTime.compute_units['normname'])
     except AttributeError as err:
         error_exit(logger, err)
 
@@ -415,7 +415,7 @@ def top_users(ComputeTime, percent, savedir, plotformat, csv=False):
     logger.debug("Top users report covering from %s to %s", *plot_daterange)
 
     # Compute units for mean compute time in pie chart
-    pie_mc_units = (ComputeTime.compute_units['name'], ComputeTime.compute_units['shortname'])
+    pie_mc_units = (ComputeTime.compute_units['normname'], ComputeTime.compute_units['shortname'])
 
     # PIE CHART OF TOP USERS
     pie_chart = pie_compute(top_users, 15, 'Top Users by Compute Time', pie_mc_units)
@@ -468,7 +468,7 @@ def top_users(ComputeTime, percent, savedir, plotformat, csv=False):
         plot['table'] /= plot_max
         plot['ymax'] = 1
     else:
-        plot_units = ComputeTime.compute_units['name']
+        plot_units = ComputeTime.compute_units['normname']
         plot['ymax'] = plot_max
 
     # Add units to main column and set index date frequency
@@ -490,7 +490,7 @@ def top_users(ComputeTime, percent, savedir, plotformat, csv=False):
     areaplot = PlotterArea(**plot)
 
     # Format ranking of top users
-    ranking_units = (ComputeTime.compute_units['name'], ComputeTime.compute_units['absolute'])
+    ranking_units = (ComputeTime.compute_units['normname'], ComputeTime.compute_units['name'])
     top_users = format_ranking_table(top_users, *ranking_units)
     top_users.index.name = 'User'
     logger.debug("Data in the ranking table: %s", ", ".join(top_users.columns))
@@ -560,7 +560,7 @@ def top_fields(ComputeTime, percent, savedir, plotformat, csv=False):
     logger.debug("Top fields report covering from %s to %s", *plot_daterange)
 
     # Compute units for mean compute time in pie chart
-    pie_mc_units = (ComputeTime.compute_units['name'], ComputeTime.compute_units['shortname'])
+    pie_mc_units = (ComputeTime.compute_units['normname'], ComputeTime.compute_units['shortname'])
 
     # PIE CHART OF TOP FIELDS
     pie_chart = pie_compute(top_fields, 15, 'Top Research Fields by Compute Time', pie_mc_units)
@@ -591,7 +591,7 @@ def top_fields(ComputeTime, percent, savedir, plotformat, csv=False):
         plot['table'] /= plot_max
         plot['ymax'] = 1
     else:
-        plot_units = ComputeTime.compute_units['name']
+        plot_units = ComputeTime.compute_units['normname']
         plot['ymax'] = plot_max
 
     # Add units to main column and set index date frequency
@@ -614,7 +614,7 @@ def top_fields(ComputeTime, percent, savedir, plotformat, csv=False):
     stackplot = PlotterStack(**plot)
 
     # Format ranking of top fields
-    ranking_units = (ComputeTime.compute_units['name'], ComputeTime.compute_units['absolute'])
+    ranking_units = (ComputeTime.compute_units['normname'], ComputeTime.compute_units['name'])
     top_fields = format_ranking_table(top_fields, *ranking_units)
     top_fields.index.name = 'Field'
     logger.debug("Data in the ranking table: %s", ", ".join(top_fields.columns))
@@ -679,7 +679,7 @@ def top_sites(ComputeTime, percent, savedir, plotformat, csv=False):
     logger.debug("Top sites report covering from %s to %s", *plot_daterange)
 
     # Compute units for mean compute time in pie chart
-    pie_mc_units = (ComputeTime.compute_units['name'], ComputeTime.compute_units['shortname'])
+    pie_mc_units = (ComputeTime.compute_units['normname'], ComputeTime.compute_units['shortname'])
 
     # PIE CHART OF TOP SITES
     pie_chart = pie_compute(top_sites, 15, 'Top Research Sites by Compute Time', pie_mc_units)
@@ -704,7 +704,7 @@ def top_sites(ComputeTime, percent, savedir, plotformat, csv=False):
         plot['table'] /= plot_max
         plot['ymax'] = 1
     else:
-        plot_units = ComputeTime.compute_units['name']
+        plot_units = ComputeTime.compute_units['normname']
         plot['ymax'] = plot_max
 
     # Format column headers and set index date frequency
@@ -725,7 +725,7 @@ def top_sites(ComputeTime, percent, savedir, plotformat, csv=False):
     lineplot = PlotterLine(**plot)
 
     # Format ranking of top fields
-    ranking_units = (ComputeTime.compute_units['name'], ComputeTime.compute_units['absolute'])
+    ranking_units = (ComputeTime.compute_units['normname'], ComputeTime.compute_units['name'])
     top_sites = format_ranking_table(top_sites, *ranking_units)
     top_sites.index.name = 'Site'
     logger.debug("Data in the ranking table: %s", ", ".join(top_sites.columns))

--- a/lib/vsc/accounting/reports.py
+++ b/lib/vsc/accounting/reports.py
@@ -63,8 +63,9 @@ def compute_time(ComputeTime, colorlist, savedir, plotformat, csv=False):
     table = ComputeTime.GlobalStats.loc[:, table_columns]
     units = ComputeTime.compute_units['name']
 
-    # Format columns in the table
+    # Format columns in the table and set index date frequency
     table = table.rename(columns=simple_names_units(table_columns, units))
+    table.index.levels[0].freq = ComputeTime.dates.freq
     logger.debug("Data included in the report: %s", ", ".join(table.columns))
 
     # Data selection for the plot
@@ -126,7 +127,7 @@ def compute_percent(ComputeTime, colorlist, savedir, plotformat, csv=False):
     table_columns.extend(['total_capacity', 'percent_total_capacity', 'global_percent_capacity'])
     table = ComputeTime.GlobalStats.loc[:, table_columns]
 
-    # Format columns in the table
+    # Format columns in the table and set index date frequency
     th = {
         'compute_time': f"Compute Time ({ComputeTime.compute_units['name']})",
         'capacity': f"Capacity ({ComputeTime.compute_units['name']})",
@@ -136,6 +137,7 @@ def compute_percent(ComputeTime, colorlist, savedir, plotformat, csv=False):
         'global_percent_capacity': "Total Capacity Used Globally (%)",
     }
     table = table.rename(columns=th)
+    table.index.levels[0].freq = ComputeTime.dates.freq
     logger.debug("Data included in the report: %s", ", ".join(table.columns))
 
     # Data selection for the plot
@@ -195,9 +197,10 @@ def global_measure(ComputeTime, selection, colorlist, savedir, plotformat, csv=F
     table_columns = ['compute_time', 'running_jobs', 'total_running_jobs', 'unique_users', 'total_unique_users']
     table = ComputeTime.GlobalStats.loc[:, table_columns]
 
-    # Format columns in the table
+    # Format columns in the table and set index date frequency
     units = [ComputeTime.compute_units['name'], 'jobs/day', 'jobs/day', 'users/day', 'users/day']
     table = table.rename(columns=simple_names_units(table_columns, units))
+    table.index.levels[0].freq = ComputeTime.dates.freq
     logger.debug("Data included in the report: %s", ", ".join(table.columns))
 
     # Data selection for the plot
@@ -282,7 +285,7 @@ def aggregates(ComputeTime, aggregate, selection, percent, colorlist, savedir, p
         entity_perc = f"{entity} - percent"
         table = AggregateStats.loc[:, [entity, entity_perc, sources['total']]]
 
-        # Format columns in the table
+        # Format columns in the table and set index date frequency
         counter_name = sources['reference'].replace('_', ' ').title()
         column_names = {
             entity: f"{counter_name} of {entity} ({sources['units']})",
@@ -290,6 +293,7 @@ def aggregates(ComputeTime, aggregate, selection, percent, colorlist, savedir, p
             sources['total']: f"Total {counter_name} ({sources['units']})",
         }
         table = table.rename(columns=column_names)
+        table.index.levels[0].freq = ComputeTime.dates.freq
         logger.debug("Data included in the report: %s", ", ".join(table.columns))
 
         # Plot title and data selection
@@ -457,9 +461,10 @@ def top_users(ComputeTime, percent, savedir, plotformat, csv=False):
         plot_units = ComputeTime.compute_units['name']
         plot['ymax'] = plot_max
 
-    # Add units to main column
+    # Add units to main column and set index date frequency
     main_column = "{} ({})".format(column_title[0], plot_units)
     plot['table'].columns = plot['table'].columns.set_levels([main_column], level=0)
+    plot['table'].index.freq = ComputeTime.dates.freq
 
     logger.debug("Data used in the area plot: %s", ", ".join(plot['table'].columns.get_level_values(1)))
     ymax_fmt = '{:.2%}' if percent else '{:.2f}'
@@ -579,9 +584,10 @@ def top_fields(ComputeTime, percent, savedir, plotformat, csv=False):
         plot_units = ComputeTime.compute_units['name']
         plot['ymax'] = plot_max
 
-    # Add units to main column
+    # Add units to main column and set index date frequency
     th = simple_names_units(plot['table'].columns, plot_units)
     plot['table'] = plot['table'].rename(columns=th)
+    plot['table'].index.levels[0].freq = ComputeTime.dates.freq
 
     logger.debug("Data used in the stack plot: %s", ", ".join(plot['table'].columns))
     ymax_fmt = '{:.2%}' if percent else '{:.2f}'
@@ -691,9 +697,10 @@ def top_sites(ComputeTime, percent, savedir, plotformat, csv=False):
         plot_units = ComputeTime.compute_units['name']
         plot['ymax'] = plot_max
 
-    # Format column headers
+    # Format column headers and set index date frequency
     column_lvl = (["Compute Time ({})".format(plot_units)], plot['table'].columns.to_list())
     plot['table'].columns = pd.MultiIndex.from_product(column_lvl)
+    plot['table'].index.freq = ComputeTime.dates.freq
 
     logger.debug("Data used in the linear plot: %s", ", ".join(plot['table'].columns.get_level_values(1)))
     ymax_fmt = '{:.2%}' if percent else '{:.2f}'

--- a/lib/vsc/accounting/reports.py
+++ b/lib/vsc/accounting/reports.py
@@ -700,15 +700,17 @@ def top_sites(ComputeTime, percent, savedir, plotformat, csv=False):
     plot_max = max(ComputeTime.GlobalStats.loc[:, 'total_compute_time'])
 
     if percent:
+        plot_ylabel = "Used Capacity"
         plot_units = '%'
         plot['table'] /= plot_max
         plot['ymax'] = 1
     else:
+        plot_ylabel = "Compute Time"
         plot_units = ComputeTime.compute_units['normname']
         plot['ymax'] = plot_max
 
     # Format column headers and set index date frequency
-    column_lvl = (["Compute Time ({})".format(plot_units)], plot['table'].columns.to_list())
+    column_lvl = (["f{plot_ylabel} (f{plot_units})"], plot['table'].columns.to_list())
     plot['table'].columns = pd.MultiIndex.from_product(column_lvl)
     plot['table'].index.freq = ComputeTime.dates.freq
 

--- a/lib/vsc/accounting/version.py
+++ b/lib/vsc/accounting/version.py
@@ -29,4 +29,4 @@ Version of vsc.accounting
 @author: Alex Domingo (Vrije Universiteit Brussel)
 """
 
-VERSION = '1.0.7'
+VERSION = '1.0.8'

--- a/lib/vsc/accounting/version.py
+++ b/lib/vsc/accounting/version.py
@@ -29,4 +29,4 @@ Version of vsc.accounting
 @author: Alex Domingo (Vrije Universiteit Brussel)
 """
 
-VERSION = '1.0.6'
+VERSION = '1.0.7'


### PR DESCRIPTION
Two version bumps for the price of one.

Bugfixes:
* handle elasticsearch errors on scan operations: https://github.com/sisc-hpc/vsc-accounting-brussel/commit/f9a12846cde145d812683e608a7c4627d7ba2df8
* fix error message in `Plotter.output_img`: https://github.com/sisc-hpc/vsc-accounting-brussel/commit/0b5e024aa789e4e39cb511d7ac6c8d771b2adc95
* some time resolutions involve variable time periods (_eg_ months with 30 and 31 days), use an average instead of the value of the first period to compute absolute units: https://github.com/sisc-hpc/vsc-accounting-brussel/commit/485072334e99a0b3d0786e990fa88b47da8a0e39
* do not allow accounting reports with a single data point: https://github.com/sisc-hpc/vsc-accounting-brussel/commit/7c9e859d0de71e0538b7ec32f785f679874d2be4
* use relative path to link images in HTML files: https://github.com/sisc-hpc/vsc-accounting-brussel/commit/90c3bcd57c5a24824d9f5970cb023c31a6525da4
* merge in the same category all users without any research field (some netids) and those VSC users having _unknown_ as research field: https://github.com/sisc-hpc/vsc-accounting-brussel/commit/a52f6caacc85a078f162e838f0cbeabb1b61b19e
* explicitly remove any names from the indexes of ranking tables, otherwise plotting them will fail due to mismatch names: https://github.com/sisc-hpc/vsc-accounting-brussel/commit/b25f48b6d0cddf20849dbb8ce5b7885f7248cae1

Enhancements:
* print log message with effective time period, which can be different to the requested time period depending on the time resolution: https://github.com/sisc-hpc/vsc-accounting-brussel/commit/91ea9d72ddc1a54a22401739f4a8567e571e5a01
* add support for absolute and relative (per day) compute units: https://github.com/sisc-hpc/vsc-accounting-brussel/commit/76350233e36d0d8be668357d7fe2afe9339d6a13, https://github.com/sisc-hpc/vsc-accounting-brussel/commit/8d3d9acdca5dda309e34b706fb784427ffe346af
* remove the complex logic to determine date frequency in plotter and just pass it through the `freq` attribute of the data table index: https://github.com/sisc-hpc/vsc-accounting-brussel/commit/7c53ea05abec3964f331db1a135f26489f110fe8
* add extra CSV with absolute compute time used to `per-X` reports: https://github.com/sisc-hpc/vsc-accounting-brussel/commit/a64f4caa5ed1c5314dd9906d881d158cb6481f88
* make activity plots of `top-X-percent` reports relative to the actual compute time used at every point in time, so that they only show the percentage of compute used by each user, field or site: https://github.com/sisc-hpc/vsc-accounting-brussel/commit/2aab70c1574243245b8591d744ddf59bec6a08e9, https://github.com/sisc-hpc/vsc-accounting-brussel/commit/7d5218c4f52de328487a1bf4b867efa5b10e672a, https://github.com/sisc-hpc/vsc-accounting-brussel/commit/d3b1d548ef2a5bf8c1b6967859b3ecbb6ab40379
* minor revision of the documentation: https://github.com/sisc-hpc/vsc-accounting-brussel/commit/8a7299c870b3b0f31213c5aa5b6e612c86bc3aac